### PR TITLE
fix bytes-like object is required issue

### DIFF
--- a/remote_ikernel/kernel.py
+++ b/remote_ikernel/kernel.py
@@ -480,7 +480,7 @@ class RemoteIKernel(object):
         # to work seamlessly. (tunnels will have already done this)
         pre = self.tunnel_hosts_cmd or ''
 
-        if ':' in self.host:
+        if str(':') in str(self.host):
             host = self.host.replace(':', ' -p ')
         else:
             host = self.host


### PR DESCRIPTION
Fix for 
```
  File "/venvs/venv-juptyerlab/lib/python3.6/site-packages/remote_ikernel/kernel.py", line 483, in tunnel_connection
    if ':' in self.host:
TypeError: a bytes-like object is required, not 'str'
```